### PR TITLE
Add installation instructions for Pipx

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@
 5. Install dependencies: `pip install -r requirements.txt`
 6. Run `python tachibk_converter.py`
 
+### [Pipx](https://pipx.pypa.io/stable/)
+
+1. Run `pipx install git+https://github.com/BrutuZ/tachibk-converter.git`
+2. Run `tachibk_converter [parameters]`
+
 ### [UV](https://github.com/astral-sh/uv)
 _There are 2 methods available:_
 


### PR DESCRIPTION
I wanted to add installation instructions for [Pipx](https://pipx.pypa.io/stable/) since IMO it's a [simpler](https://files.catbox.moe/yuewq2.png) (no fussing about with venv activation/deactivation, just run the executable that's now on your system path) permanent installation method that suits a CLI app like this.